### PR TITLE
SERVER-56544 allow udp_socket:read

### DIFF
--- a/selinux/mongodb.te
+++ b/selinux/mongodb.te
@@ -219,7 +219,7 @@ allow mongod_t proc_t:lnk_file { getattr read };
 allow mongod_t self:capability net_bind_service;
 allow mongod_t self:process execmem;
 allow mongod_t self:tcp_socket { accept bind connect name_connect create getattr getopt listen setopt shutdown read write };
-allow mongod_t self:udp_socket { create connect write };
+allow mongod_t self:udp_socket { create connect read write };
 allow mongod_t shell_exec_t:file { getattr open map read ioctl lock execute execute_no_trans };
 allow mongod_t shell_exec_t:file map;
 allow mongod_t sysctl_net_t:dir { getattr search open read lock ioctl };


### PR DESCRIPTION
This extra permission is apparently required for DNS resolution to work. Without it (formatted/line breaks):

```
Sep 28 17:01:36 ip-10-122-52-166.ec2.internal mongod[9886]: 
   {"t":{"$date":"2021-09-28T17:01:36.274+00:00"},"s":"F",  "c":"CONTROL",  "id":20575,
   "ctx":"main","msg":"Error creating service context", "attr":{"error":
   "DNSHostNotFound: Can't connect to the specified LDAP servers, error: LDAP Host: ldaptest.10gen.cc was NOT successfully resolved."}}
```