### PR TITLE
fix: allow mongod_t to search var_lib_nfs_t dirs for FTDC disk stats

### DIFF
--- a/selinux/mongodb.te
+++ b/selinux/mongodb.te
@@ -64,6 +64,11 @@ files_pid_filetrans(mongod_t, mongod_runtime_t, { dir file sock_file })
 
 require { type var_t, var_run_t; }
 allow mongod_t var_t:dir { getattr search open };
+
+# FTDC iterates all mount points via statfs(2) for disk statistics collection;
+# allow search on NFS-related dirs to avoid spurious denials
+require { type var_lib_nfs_t; }
+allow mongod_t var_lib_nfs_t:dir search;
 allow mongod_t var_run_t:lnk_file { getattr read };
 allow mongod_t var_run_t:dir { open read getattr lock search ioctl add_name remove_name write };
 type_transition mongod_t var_run_t:dir mongod_runtime_t;


### PR DESCRIPTION
FTDC disk statistics collection triggers SELinux AVC denials when traversing NFS-related virtual filesystem paths.

MongoDB FTDC uses statfs(2) to iterate over all mounted filesystems in order to collect disk statistics. On systems where /var/lib/nfs/rpc_pipefs is present and labeled as var_lib_nfs_t, this traversal results in SELinux denying directory search access for mongod_t.

This leads to repeated AVC denials in audit logs during FTDC execution.

This change allows mongod_t to perform directory search on var_lib_nfs_t paths, enabling FTDC to complete mount point enumeration without generating SELinux denials.

Only directory traversal (`search`) is permitted. No read or write access to filesystem contents is granted.

Tested on RHEL 9:
- Built and installed policy using `make && make install`
- Verified that AVC denials no longer appear under FTDC disk stats collection
- No additional SELinux denials observed

This issue is observed in replica set / cluster deployments where FTDC disk statistics collection is more active. It was not observed in standalone MongoDB deployments.

Closes #16